### PR TITLE
Add data-aria-controls to mergeable attribute list

### DIFF
--- a/lib/html_attributes_utils.rb
+++ b/lib/html_attributes_utils.rb
@@ -15,6 +15,7 @@ module HTMLAttributesUtils
     %i(aria describedby),
     %i(aria flowto),
     %i(aria labelledby),
+    %i(data aria controls),
     %i(aria owns),
     %i(rel),
   ].freeze

--- a/lib/html_attributes_utils.rb
+++ b/lib/html_attributes_utils.rb
@@ -8,7 +8,7 @@ module HTMLAttributesUtils
   # They are stored as nested arrays so when we're walking multiple
   # levels on the deep merge the structure can be identified. This means
   # the library works with the Rails-preferred format of
-  # `aria: { describedby: "xyz" }` rather than `aria-describdby: `xyz`
+  # `aria: { describedby: "xyz" }` rather than `"aria-describdby" => "xyz"`
   DEFAULT_MERGEABLE_ATTRIBUTES = [
     %i(class),
     %i(aria controls),

--- a/spec/lib/html_attribute_utils_spec.rb
+++ b/spec/lib/html_attribute_utils_spec.rb
@@ -247,7 +247,7 @@ describe "DEFAULT_MERGEABLE_ATTRIBUTES" do
   subject { HTMLAttributesUtils::DEFAULT_MERGEABLE_ATTRIBUTES }
 
   let(:expected) do
-    [%i(class), %i(aria controls), %i(aria describedby), %i(aria flowto), %i(aria labelledby), %i(aria owns), %i(rel)]
+    [%i(class), %i(aria controls), %i(aria describedby), %i(aria flowto), %i(aria labelledby), %i(aria owns), %i(data aria controls), %i(rel)]
   end
 
   it { is_expected.to match_array(expected) }


### PR DESCRIPTION
GOV.UK frontend uses `data-aria-controls` instead of `aria-controls` because `aria-controls` would only be correct once the JavaScript component has initialised and (in the case of revealing checkbox/radio button content) the content hidden.

This library should treat it in the same way we treat `aria-controls` and make it mergeable.

Refs x-govuk/govuk-form-builder/pull/440
