### PR TITLE
Change 'aria controls' for 'aria_controls'

### DIFF
--- a/lib/html_attributes_utils.rb
+++ b/lib/html_attributes_utils.rb
@@ -15,7 +15,7 @@ module HTMLAttributesUtils
     %i(aria describedby),
     %i(aria flowto),
     %i(aria labelledby),
-    %i(data aria controls),
+    %i(data aria_controls),
     %i(aria owns),
     %i(rel),
   ].freeze

--- a/spec/lib/html_attribute_utils_spec.rb
+++ b/spec/lib/html_attribute_utils_spec.rb
@@ -247,7 +247,7 @@ describe "DEFAULT_MERGEABLE_ATTRIBUTES" do
   subject { HTMLAttributesUtils::DEFAULT_MERGEABLE_ATTRIBUTES }
 
   let(:expected) do
-    [%i(class), %i(aria controls), %i(aria describedby), %i(aria flowto), %i(aria labelledby), %i(aria owns), %i(data aria controls), %i(rel)]
+    [%i(class), %i(aria controls), %i(aria describedby), %i(aria flowto), %i(aria labelledby), %i(aria owns), %i(data aria_controls), %i(rel)]
   end
 
   it { is_expected.to match_array(expected) }


### PR DESCRIPTION
When `aria controls` is separated by a space it intruduces an unwanted third level of nesting, we want `data: { aria-controls: 'xyz' }` so add the underscore which is converted by Rails into a dash.

Refs x-govuk/govuk-form-builder/pull/440
